### PR TITLE
fix chlu-did not working due to compiled js

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "name": "Chlu",
     "email": "info@chlu.io",
     "url": "https://chlu.io"
-  }  
+  }
 }

--- a/src/ipfs-did.js
+++ b/src/ipfs-did.js
@@ -1,7 +1,7 @@
 const log = require('./log')
 const CID = require('cids')
 const { dagGetResultToObject, isCID } = require('./ipfs')
-const ChluDID = require('chlu-did')
+const ChluDID = require('chlu-did/src')
 
 class ChluIPFSDID {
     constructor(ipfs, db) {

--- a/tests/http.test.js
+++ b/tests/http.test.js
@@ -2,7 +2,7 @@ const getWebServer = require('../src/http')
 const sinon = require('sinon')
 const expect = require('chai').expect
 const request = require('supertest')
-const ChluDID = require('chlu-did')
+const ChluDID = require('chlu-did/src')
 const log = require('../src/log')
 
 describe('HTTP server', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,19 +559,19 @@ chloride-test@^1.1.0:
     json-buffer "^2.0.11"
 
 chloride@^2.2.8:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/chloride/-/chloride-2.2.9.tgz#f469ed1fb1acb9195b567d900dc9bb6d205df08e"
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/chloride/-/chloride-2.2.10.tgz#cb68ddeed9328a63b8bd6e1585ed584c8e122f23"
   dependencies:
     is-electron "^2.0.0"
     sodium-browserify "^1.2.4"
     sodium-browserify-tweetnacl "^0.2.2"
     sodium-chloride "^1.1.0"
   optionalDependencies:
-    sodium-native "^2.0.0"
+    sodium-native "^2.1.6"
 
 chlu-did@ChluNetwork/chlu-did:
   version "1.0.0"
-  resolved "https://codeload.github.com/ChluNetwork/chlu-did/tar.gz/469a99f3518065e1b328b307e0a4ce25160ebe61"
+  resolved "https://codeload.github.com/ChluNetwork/chlu-did/tar.gz/fb253f8fc0f62ceb5f0296f295637e76514b5111"
   dependencies:
     brorand "^1.1.0"
     bs58 "4.0.1"
@@ -2254,8 +2254,8 @@ jsonld-signatures@2.3.0:
     semver "^5.5.0"
 
 jsonld@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-1.0.1.tgz#97c6ca0db65edce1d7677e319e973aab932b5cba"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-1.0.2.tgz#c08118a4fa4a8457bf98891653ed1f1613eb6152"
   dependencies:
     rdf-canonize "^0.2.1"
     request "^2.83.0"
@@ -3947,8 +3947,8 @@ request@2.83.0:
     uuid "^3.1.0"
 
 request@^2.83.0:
-  version "2.85.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.6.0"
@@ -3958,7 +3958,6 @@ request@^2.83.0:
     forever-agent "~0.6.1"
     form-data "~2.3.1"
     har-validator "~5.0.3"
-    hawk "~6.0.2"
     http-signature "~1.2.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
@@ -3968,7 +3967,6 @@ request@^2.83.0:
     performance-now "^2.1.0"
     qs "~6.5.1"
     safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
@@ -4022,6 +4020,10 @@ safe-buffer@5.1.1:
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+safer-buffer@^2.0.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 samsam@1.3.0:
   version "1.3.0"
@@ -4275,7 +4277,7 @@ sodium-chloride@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/sodium-chloride/-/sodium-chloride-1.1.0.tgz#247a234b88867f6dff51332b605f193a65bf6839"
 
-sodium-native@^2.0.0:
+sodium-native@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-2.1.6.tgz#4c130a61fe4cddf029d14f6f61489a2efde49cad"
   dependencies:
@@ -4326,13 +4328,14 @@ sprintf-js@1.1.0:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.0.tgz#cffcaf702daf65ea39bb4e0fa2b299cec1a1be46"
 
 sshpk@^1.7.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb"
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
     dashdash "^1.12.0"
     getpass "^0.1.1"
+    safer-buffer "^2.0.2"
   optionalDependencies:
     bcrypt-pbkdf "^1.0.0"
     ecc-jsbn "~0.1.1"
@@ -4423,8 +4426,8 @@ string_decoder@~1.1.1:
     safe-buffer "~5.1.0"
 
 stringstream@~0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Doing this to get chlu-did-service to start on our infrastructure.

Apparently, the compiled sources in `lib` for `chlu-did` don't work from node.js due to `module regeneratorRuntime not found`

I think it needs `babel-polyfill` but then we will have to add that in every project with chlu-did?

For now I'm importing the es6 sources